### PR TITLE
chore: release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
-# 🚀 Changelog - n8n-nodes-neo4j-extended# 🚀 Changelog - n8n-nodes-neo4j-extended
+# 🚀 Changelog - n8n-nodes-neo4j-extended
 
+## [1.0.4] - 2024-10-01
 
+### 📦 Release
+
+- Bumped package version to publish the 1.0.3 AI agent integration hotfix to npm.
+
+### 🔧 Improvements
+
+- Added automatic fallback from `neo4j://` routing URLs to direct `bolt://` connections when routing discovery fails.
+- Applied the same fallback strategy to vector store initialisation so AI tool operations remain available during routing outages.
+- Introduced shared helpers for detecting routing errors, ensuring retries only trigger for genuine discovery issues.
 
 ## [1.0.3] - 2024-09-29 - HOTFIX## [1.1.0] - 2024-09-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-neo4j-extended",
-  "version": "0.1.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-neo4j-extended",
-      "version": "0.1.0",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@langchain/community": "^0.3.56",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-neo4j-extended",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "n8n community node for Neo4j with vector search, graph database operations, and AI tool integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- bump the package version to 1.0.4 for the next npm publish
- document the 1.0.4 release in the changelog, including the Neo4j connection fallback improvements

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbe7753c5c8320a21e16eee14133ee